### PR TITLE
add API for testcases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       - default
   judge:
     image: njudge-judge
-    ports:
-      - 8080:8080
     privileged: true
     cgroup: host
     env_file:

--- a/internal/judge/judge.go
+++ b/internal/judge/judge.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/karrick/gobls"
@@ -121,16 +120,7 @@ func (j *Judge) Judge(ctx context.Context, sub Submission, callback ResultCallba
 	return &res, err
 }
 
-type InputOutput struct {
-	In  string
-	Out string
-}
-
-type TestcasesResponse struct {
-	Testcases []InputOutput
-}
-
-func (j *Judge) GetTestcases(problemName string) (*TestcasesResponse, error) {
+func (j *Judge) GetTestcases(problemName string) ([]problems.Testcase, error) {
 	problem, err := j.ProblemStore.GetProblem(problemName)
 	if err != nil {
 		return nil, err
@@ -139,23 +129,13 @@ func (j *Judge) GetTestcases(problemName string) (*TestcasesResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	var testcases []InputOutput
+	var testcases []problems.Testcase
 	for _, testset := range st.Feedback {
 		for _, group := range testset.Groups {
-			for _, tc := range group.Testcases {
-				in, err := os.ReadFile(tc.InputPath)
-				if err != nil {
-					return nil, err
-				}
-				out, err := os.ReadFile(tc.AnswerPath)
-				if err != nil {
-					return nil, err
-				}
-				testcases = append(testcases, InputOutput{In: string(in), Out: string(out)})
-			}
+			testcases = append(testcases, group.Testcases...)
 		}
 	}
-	return &TestcasesResponse{Testcases: testcases}, nil
+	return testcases, nil
 }
 
 type Client struct {

--- a/internal/judge/server.go
+++ b/internal/judge/server.go
@@ -135,8 +135,8 @@ func (s Server) GetTestcasesHandler() echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid file name")
 		}
 		index, err := strconv.Atoi(match[2])
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "invalid file name")
+		if err != nil || index >= len(testcases) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid testcase index")
 		}
 		if match[1] == "input" {
 			return c.File(testcases[index].InputPath)


### PR DESCRIPTION
New API endpoints: `/testcases/<problem>/input<n>.txt`, `/testcases/<problem>/output<n>.txt`
Supports gzip compression, HEAD requests and Range headers.
Examples:
- `/testcases/OKTV24_TiltottPar/input0.txt`
- `/testcases/OKTV24_TiltottPar/output2.txt`