### PR TITLE
Cache pre-compiled `bits/stdc++.h` headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/a-h/templ v0.2.778
 	github.com/antonlindstrom/pgstore v0.0.0-20220421113606-e3a6e3fed12a
 	github.com/erni27/imcache v1.2.0
+	github.com/gofrs/flock v0.12.1
 	github.com/karrick/gobls v1.3.5
 	github.com/quasoft/memstore v0.0.0-20191010062613-2bce066d2b0b
 	github.com/samber/slog-echo v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=

--- a/internal/web/handlers/problemset/recorder.go
+++ b/internal/web/handlers/problemset/recorder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mraron/njudge/pkg/problems/evaluation"
 	"io"
 	"io/fs"
+	"os"
 	"strings"
 )
 
@@ -41,6 +42,10 @@ func (r *recordingSandbox) CreateFile(file sandbox.File) error {
 
 func (r *recordingSandbox) Create(name string) (io.WriteCloser, error) {
 	return closer{io.Discard}, nil
+}
+
+func (r *recordingSandbox) MkdirAll(name string, perm os.FileMode) error {
+	return nil
 }
 
 func (r *recordingSandbox) MakeExecutable(name string) error {

--- a/pkg/language/sandbox/fs.go
+++ b/pkg/language/sandbox/fs.go
@@ -38,6 +38,13 @@ func (o OsFS) Create(name string) (io.WriteCloser, error) {
 	return os.Create(o.getPathTo(name))
 }
 
+func (o OsFS) MkdirAll(name string, perm os.FileMode) error {
+	if !o.inited {
+		return ErrorSandboxNotInitialized
+	}
+	return os.MkdirAll(o.getPathTo(name), perm)
+}
+
 func (o OsFS) MakeExecutable(name string) error {
 	if !o.inited {
 		return ErrorSandboxNotInitialized

--- a/pkg/language/sandbox/sandbox.go
+++ b/pkg/language/sandbox/sandbox.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/mraron/njudge/pkg/language/memory"
 	"io"
 	"io/fs"
 	"os"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/mraron/njudge/pkg/language/memory"
 )
 
 // ErrorSandboxNotInitialized should returned when a Run is called on a Sandbox without a prior Init call.
@@ -25,6 +26,7 @@ var ErrorSandboxNotInitialized = errors.New("initialize the sandbox first")
 type FS interface {
 	Pwd() string
 	Create(name string) (io.WriteCloser, error)
+	MkdirAll(name string, perm os.FileMode) error
 	MakeExecutable(name string) error
 
 	fs.FS


### PR DESCRIPTION
A significant part of compiling simple C++ programs is taken up by the
parsing and analysis of the enormous `bits/stdc++.h` header. GCC's
pre-compiled headers (PCH) feature allows most of this work to be cached
by dumping this data out to a `.gch` file. These files are tied to both
the exact compiler flags as well as the specific compiler binary.
Therefore, a dynamic caching method is used which generates the PCH if
one with the appropriate key isn't available.

A later commit will add support for limiting the maximum cache size.

This will be used in the IDE's executor service, but this could be added
to the njudge website too.