### PR TITLE
Do not leak isolate metafiles

### DIFF
--- a/pkg/language/sandbox/isolate.go
+++ b/pkg/language/sandbox/isolate.go
@@ -129,7 +129,7 @@ func (i *Isolate) Run(_ context.Context, config RunConfig, toRun string, toRunAr
 	}
 	defer func(metafile *os.File) {
 		_ = metafile.Close()
-		_ = os.Remove(filepath.Join(os.TempDir(), metafile.Name()))
+		_ = os.Remove(metafile.Name())
 	}(metafile)
 
 	args = append(args, fmt.Sprintf("--meta=%s", metafile.Name()))


### PR DESCRIPTION
The `Name()` method returns an absolute path for files created with `os.CreateTemp()`, so prepending `os.TempDir()` is incorrect and causes the `os.Remove()` call to fail.
