### PR TITLE
njudge/email: add mailersend support

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -37,6 +37,7 @@ var DefaultWebConfig = WebConfig{
 		TimeZone:       "Europe/Budapest",
 		CookieSecret:   "svp3r_s3cr3t",
 		GoogleAuth:     web.GoogleAuthConfig{},
+		MailerSend:     web.MailerSendConfig{},
 		Sendgrid:       web.SendgridConfig{},
 		SMTP:           web.SMTPConfig{},
 		DatabaseConfig: _dockerDatabaseConfig,

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/quasoft/memstore v0.0.0-20191010062613-2bce066d2b0b
 	github.com/samber/slog-echo v1.14.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.7.1
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.28.0
@@ -56,6 +56,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ericlagergren/decimal v0.0.0-20190420051523-6335edbaa640 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/context v1.1.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
@@ -63,6 +64,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mailersend/mailersend-go v1.6.2 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -372,6 +374,8 @@ github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mailersend/mailersend-go v1.6.2 h1:YAJJ0d3kWyBA8tXRSGwGW3kcba6ga6DxGzElofIUigw=
+github.com/mailersend/mailersend-go v1.6.2/go.mod h1:52k/GIPtXPwOmAwIwOJP34kde6Ep8xTWCDpwZWLJmFc=
 github.com/markbates/goth v1.80.0 h1:NnvatczZDzOs1hn9Ug+dVYf2Viwwkp/ZDX5K+GLjan8=
 github.com/markbates/goth v1.80.0/go.mod h1:4/GYHo+W6NWisrMPZnq0Yr2Q70UntNLn7KXEFhrIdAY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -531,6 +535,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=

--- a/internal/njudge/email/service.go
+++ b/internal/njudge/email/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"gopkg.in/gomail.v2"
+
+	"github.com/mailersend/mailersend-go"
 )
 
 // Service sends and email
@@ -64,6 +66,40 @@ func (s SendgridService) Send(ctx context.Context, m Mail) error {
 
 	client := sendgrid.NewSendClient(s.APIKey)
 	_, err := client.SendWithContext(ctx, message)
+	return err
+}
+
+type MailerSendService struct {
+	SenderName    string
+	SenderAddress string
+	APIKey        string
+}
+
+func (s MailerSendService) Send(ctx context.Context, m Mail) error {
+	client := mailersend.NewMailersend(s.APIKey)
+
+	message := client.Email.NewMessage()
+
+	from := mailersend.Recipient{Name: s.SenderName, Email: s.SenderAddress}
+	recipients := []mailersend.Recipient{}
+
+	for _, addr := range m.Recipients {
+		recipients = append(recipients, mailersend.Recipient{
+			Name:  "",
+			Email: addr,
+		})
+	}
+
+	htmlContent := m.Message
+	plainTextContent := StripHTMLRegex(m.Message)
+
+	message.SetSubject(m.Subject)
+	message.SetFrom(from)
+	message.SetRecipients(recipients)
+	message.SetHTML(htmlContent)
+	message.SetText(plainTextContent)
+
+	_, err := client.Email.Send(ctx, message)
 	return err
 }
 

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -75,6 +75,13 @@ type GoogleAuthConfig struct {
 	Secret    string `mapstructure:"secret" yaml:"secret"`
 }
 
+type MailerSendConfig struct {
+	Enabled       bool   `yaml:"enabled" mapstructure:"enabled"`
+	ApiKey        string `yaml:"api_key" mapstructure:"api_key"`
+	SenderName    string `yaml:"sender_name" mapstructure:"sender_name"`
+	SenderAddress string `yaml:"sender_address" mapstructure:"sender_address"`
+}
+
 type SendgridConfig struct {
 	Enabled       bool   `yaml:"enabled" mapstructure:"enabled"`
 	ApiKey        string `yaml:"api_key" mapstructure:"api_key"`
@@ -100,6 +107,8 @@ type Config struct {
 
 	GoogleAuth GoogleAuthConfig `mapstructure:"google_auth" yaml:"google_auth"`
 
+	MailerSend MailerSendConfig `yaml:"mailersend" mapstructure:"mailersend"`
+
 	Sendgrid SendgridConfig `yaml:"sendgrid" mapstructure:"sendgrid"`
 
 	SMTP SMTPConfig `yaml:"smtp" mapstructure:"smtp"`
@@ -121,6 +130,12 @@ func (s Config) EmailService() email.Service {
 			SenderName:    s.Sendgrid.SenderName,
 			SenderAddress: s.Sendgrid.SenderAddress,
 			APIKey:        s.Sendgrid.ApiKey,
+		}
+	} else if s.MailerSend.Enabled {
+		return email.MailerSendService{
+			SenderName:    s.MailerSend.SenderName,
+			SenderAddress: s.MailerSend.SenderAddress,
+			APIKey:        s.MailerSend.ApiKey,
 		}
 	} else {
 		if s.Mode == ModeDevelopment || s.Mode == ModeDebug || s.Mode == ModeDemo {
@@ -160,6 +175,11 @@ func (s Config) Valid() error {
 	if s.Sendgrid.Enabled {
 		if s.Sendgrid.ApiKey == "" {
 			return fmt.Errorf("sendgrid api key is required")
+		}
+	}
+	if s.MailerSend.Enabled {
+		if s.MailerSend.ApiKey == "" {
+			return fmt.Errorf("mailersend api key is required")
 		}
 	}
 	return nil


### PR DESCRIPTION
Add support for using malersend to send emails. Similarly to sendgrid, they also offer a similar go client library, so this is more or less a copy-paste of the sendgrid parts.